### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/application.py
+++ b/application.py
@@ -84,22 +84,25 @@ def uploaded():
                 return render_template('error.html', err=err)
             else:
                 print(f"{Fore.GREEN}[+] file uploded ! {file_name}{Fore.RESET}")
-                path = f'{Path(__file__).parent}'
-                path_full_write = f"{path}\\files\{file_name}"
-                content = readfile(file_name)
+                base_path = os.path.abspath(f'{Path(__file__).parent}/files')
+                path_full_write = os.path.normpath(os.path.join(base_path, file_name))
+                if not path_full_write.startswith(base_path):
+                    err = "Invalid file path"
+                    return render_template('error.html', err=err)
+                content = readfile(path_full_write)
                 writefile(path_full_write, content)
 
 
     return render_template('upload.html', file_content=file_content)
 
-def  readfile(file_name):
-    with open (file_name, "r") as fichier:
+def  readfile(file_path):
+    with open (file_path, "r") as fichier:
         content = fichier.read()
     return content
 
 
-def writefile(full_path, content):
-    with open(full_path, "w+") as fichier:
+def writefile(file_path, content):
+    with open(file_path, "w+") as fichier:
         fichier.write(content)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/jbibila/Formation-DSO/security/code-scanning/5](https://github.com/jbibila/Formation-DSO/security/code-scanning/5)

To fix the problem, we need to ensure that the file path constructed from user input is safe and does not allow access to files outside the intended directory. This can be achieved by normalizing the path and verifying that it starts with the expected base directory.

1. Normalize the path using `os.path.normpath` to remove any ".." segments.
2. Check that the normalized path starts with the base directory to ensure it is within the allowed directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
